### PR TITLE
Update import pattern to allow semicolon to be optional

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -37,6 +37,6 @@ test("include", async () => {
 
   if (data.modules === undefined) return;
   expect(data.modules[0].source).toBe(
-    `export default "// included\\n\\n// nested included"`
+    `export default "// included, no semicolon\\n\\n// nested included"`
   );
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,7 +14,7 @@ async function parse(
   source: string,
   context: string
 ): Promise<string> {
-  const importPattern = /#include "([./\w_-]+)";/gi;
+  const importPattern = /#include "([./\w_-]+)";?/gi;
 
   // Find all imports
   const imports: Import[] = [];

--- a/test/included.glsl
+++ b/test/included.glsl
@@ -1,3 +1,3 @@
-// included
+// included, no semicolon
 
-#include "./nestedIncluded.glsl";
+#include "./nestedIncluded.glsl"


### PR DESCRIPTION
Some GLSL parsers support the `#include "./file.glsl"` syntax only without the `;` (as with the semicolon it would be considered a syntax error), so with this PR, include statements without semicolons will also work