### PR TITLE
Fix some paths failing to resolve

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -45,7 +45,12 @@ async function processImports(
   }
 
   // Resolve import path
-  const resolvedPath = await loader.getResolve()(context, imp.key);
+  let resolvedPath: string;
+  try {
+    resolvedPath = await loader.getResolve()(context, "./" + imp.key);
+  } catch {
+    resolvedPath = await loader.getResolve()(context, imp.key);
+  }
   loader.addDependency(resolvedPath);
 
   // Parse import


### PR DESCRIPTION
Some paths in Lygia are in the format of `#include "subfolder/file.glsl"`, where it is not prefixed with a `./`. This PR fixes this by trying to import first with an added `./`, then calling the function like before. This should not change existing workflows