### PR TITLE
Add multiline flag to support commented out imports

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -36,7 +36,13 @@ test("include", async () => {
   expect(data.modules).toBeDefined();
 
   if (data.modules === undefined) return;
+  const contentTest = `// included
+
+// nested included
+
+// should not import this one:
+//#include "./doesnotexist.glsl"`;
   expect(data.modules[0].source).toBe(
-    `export default "// included\\n\\n// nested included"`
+    `export default ${JSON.stringify(contentTest)}`
   );
 });

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -14,7 +14,7 @@ async function parse(
   source: string,
   context: string
 ): Promise<string> {
-  const importPattern = /#include "([./\w_-]+)";/gi;
+  const importPattern = /^#include "([./\w_-]+)";/gmi;
 
   // Find all imports
   const imports: Import[] = [];

--- a/test/nestedIncluded.glsl
+++ b/test/nestedIncluded.glsl
@@ -1,1 +1,4 @@
 // nested included
+
+// should not import this one:
+//#include "./doesnotexist.glsl"


### PR DESCRIPTION
When you comment out an import like such:
```glsl
//#include "someFile.glsl"
```
the file will still be imported, but the first line of the file will be commented. This is particularly problematic for Lygia files, because they start with a multiline comment (`/*`), and thus the multiline comment start symbol gets commented out (`///*`), which results in a syntax error. This PR fixes that by having the `#include` regex only work on line starts.