### PR TITLE
Fix platform dependent newlines

### DIFF
--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -31,7 +31,7 @@ test("include", async () => {
   const { stats, bundleJs } = await testCompiler(shader("includer.glsl"));
   const data = stats.toJson({ source: true });
 
-  console.log(bundleJs, stats.toJson());
+  //console.log(bundleJs, stats.toJson());
 
   expect(data.errors).toEqual([]);
   expect(data.modules).toBeDefined();

--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -1,6 +1,7 @@
 import { testCompiler } from "../test/compiler";
 import * as fs from "fs";
 import * as path from "path";
+import * as os from "os";
 
 const shader = (filename: string) =>
   path.resolve(__dirname, `../test/${filename}`);
@@ -37,6 +38,6 @@ test("include", async () => {
 
   if (data.modules === undefined) return;
   expect(data.modules[0].source).toBe(
-    `export default "// included\\n\\n// nested included"`
+    `export default "// included${os.EOL}${os.EOL}// nested included"`
   );
 });

--- a/lib/index.spec.ts
+++ b/lib/index.spec.ts
@@ -37,7 +37,12 @@ test("include", async () => {
   expect(data.modules).toBeDefined();
 
   if (data.modules === undefined) return;
+
+  const eol = os.EOL
+      .replace("\r", "\\r")
+      .replace("\n", "\\n");
+
   expect(data.modules[0].source).toBe(
-    `export default "// included${os.EOL}${os.EOL}// nested included"`
+    `export default "// included${eol}${eol}// nested included"`
   );
 });


### PR DESCRIPTION
The current test case works only when the system line separator is `\n`, but when tests are ran on platforms such as Windows, the newline will be `\r\n`, thus failing the test. This PR fixes this by using the OS platform separator in the test.