### PR TITLE
Fix publish because of wrong run order on tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "jest",
     "lint": "eslint",
     "build": "tsc",
-    "prepublishOnly": "npm run test && npm run lint && npm run build"
+    "prepublishOnly": "npm run build && npm run lint && npm run test"
   },
   "files": [
     "lib/index.js",


### PR DESCRIPTION
Currently, when trying to publish the repo, the `prepublishOnly` task runs the `test` task first, which fails when the tests are not recompiled. This PR fixes this by changing this order to first build the source, then test it.